### PR TITLE
[calligra] Add 0001-calligra-Fix-infinite-loop-while-trying-to-translate...

### DIFF
--- a/rpm/0001-calligra-Fix-infinite-loop-while-trying-to-translate.patch
+++ b/rpm/0001-calligra-Fix-infinite-loop-while-trying-to-translate.patch
@@ -1,0 +1,41 @@
+From 56814b20e1cf1ff916316aabfcf216da12ef2bda Mon Sep 17 00:00:00 2001
+From: Mohammed Hassan <mohammed.hassan@jolla.com>
+Date: Fri, 21 Mar 2014 18:30:45 +0200
+Subject: [PATCH] [calligra] Fix infinite loop while trying to translate the
+ boundingRect for a KoShape
+
+---
+ calligra/components/impl/PresentationImpl.cpp | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/calligra/components/impl/PresentationImpl.cpp b/calligra/components/impl/PresentationImpl.cpp
+index cdb50c7..5c341f6 100644
+--- a/calligra/components/impl/PresentationImpl.cpp
++++ b/calligra/components/impl/PresentationImpl.cpp
+@@ -76,8 +76,10 @@ public:
+         foreach(const KoShape* shape, koPaView->activePage()->shapes()) {
+             if(!shape->hyperLink().isEmpty()) {
+                 QRectF rect = shape->boundingRect();
+-                while(KoShapeContainer* parent = shape->parent()) {
++                KoShapeContainer *parent = shape->parent();
++                while(parent) {
+                     rect.translate(parent->position());
++                    parent = parent->parent();
+                 }
+                 links.append(QPair<QRectF, QUrl>(rect, QUrl(shape->hyperLink())));
+             }
+@@ -105,8 +107,10 @@ public:
+                                 if(shapeData->document() == text)
+                                 {
+                                     rect.translate(shape->position());
+-                                    while(KoShapeContainer* parent = shape->parent()) {
++                                    KoShapeContainer *parent = shape->parent();
++                                    while(parent) {
+                                         rect.translate(parent->position());
++                                        parent = parent->parent();
+                                     }
+                                     break;
+                                 }
+-- 
+1.8.4.rc3
+

--- a/rpm/calligra.spec
+++ b/rpm/calligra.spec
@@ -9,6 +9,7 @@ Release: 1%{?dist}
 Group: Applications/Productivity
 URL: http://www.calligra.org/
 Source0: %{name}-%{version}.tar.gz
+Patch0:  0001-calligra-Fix-infinite-loop-while-trying-to-translate.patch
 Summary: Calligra Suite
 License: Open
 BuildRequires: cmake
@@ -1271,6 +1272,7 @@ Group: Development/Libraries
 
 %prep
 %setup -q -n %{name}-%{version}/calligra
+%patch0 -p1
 
 %build
 mkdir -p build && cd build


### PR DESCRIPTION
....patch

This fixes an infinite loop while trying to translate the boundingRect for a KoShape
