### PR TITLE
[calligra] Work around QLocale().timeFormat().simplified() seg faulting in Qt5.6.

### DIFF
--- a/calligra/sheets/ValueParser.cpp
+++ b/calligra/sheets/ValueParser.cpp
@@ -390,7 +390,10 @@ Value ValueParser::tryParseTime(const QString& str, bool *ok) const
 QDateTime ValueParser::readTime(const QString& intstr, bool withSeconds, bool* ok) const
 {
     QString str = intstr.simplified().toLower();
-    QString format = m_settings->locale()->timeFormat().simplified();
+    // Workaround segfault with gcc 4.8 and Qt5.6 when calling
+    // m_settings->locale()->timeFormat().simplified() all in one line.
+    QString timeFormat = m_settings->locale()->timeFormat();
+    QString format = timeFormat.simplified();
     if (!withSeconds) {
         int n = format.indexOf("%S");
         format = format.left(n - 1);


### PR DESCRIPTION
This is an ugly workaround to avoid segmentation fault when opening a spreadsheet in sailfish-office with Qt5.6.

The ```-std=c++0x``` flag make the following code segmentation fault:
<pre>
#include &lt;QLocale>
#include &lt;stdio.h>

int main(int argc, char ** argv)
{
  fprintf(stderr, "'%s'\n", QLocale().timeFormat().simplified().toLocal8Bit().data());
  return 0;
}
</pre>

Maybe this code is illegal for C++ standard, I don't know. It's working well without the flag though.